### PR TITLE
longer llm setup timeout, avoid failure loading llama3.2 models

### DIFF
--- a/src/api/api_llm.cpp
+++ b/src/api/api_llm.cpp
@@ -47,7 +47,7 @@ String ApiLlm::setup(ApiLlmSetupConfig_t config, String request_id)
             // Copy work id
             llm_work_id = msg.work_id;
         },
-        10000);
+        60000);
     return llm_work_id;
 }
 


### PR DESCRIPTION
## About this PR

When using "openbuddy-llama3.2-1B-ax630c" model like below, setup of this model takes about 15sec, but it fails because the timeout value of module_llm.llm.setup() is 10sec.

```cpp
    m5_module_llm::ApiLlmSetupConfig_t llm_config;
    llm_config.model = "openbuddy-llama3.2-1B-ax630c";
    llm_work_id = module_llm.llm.setup(llm_config);
```

So I modified the timeout value to be longer 10sec -> 60sec, so that it succeeds to setup large models.

ref: https://github.com/m5stack/StackFlow/issues/2