### PR TITLE
Changed to automatically detect pin settings in sample code.

### DIFF
--- a/examples/KWS_ASR/KWS_ASR.ino
+++ b/examples/KWS_ASR/KWS_ASR.ino
@@ -27,9 +27,12 @@ void setup()
     // language = "zh_CN";
 
     /* Init module serial port */
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
-    // Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
-    // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
+    // int rxd = 16, txd = 17;  // Basic
+    // int rxd = 13, txd = 14;  // Core2
+    // int rxd = 18, txd = 17;  // CoreS3
+    int rxd = M5.getPin(m5::pin_name_t::port_c_rxd);
+    int txd = M5.getPin(m5::pin_name_t::port_c_txd);
+    Serial2.begin(115200, SERIAL_8N1, rxd, txd);
 
     /* Init module */
     module_llm.begin(&Serial2);

--- a/examples/SerialTextAssistant/SerialTextAssistant.ino
+++ b/examples/SerialTextAssistant/SerialTextAssistant.ino
@@ -25,9 +25,12 @@ void setup()
     CommSerialPort.begin(115200);
 
     /* Init module serial port */
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
-    // Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
-    // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
+    // int rxd = 16, txd = 17;  // Basic
+    // int rxd = 13, txd = 14;  // Core2
+    // int rxd = 18, txd = 17;  // CoreS3
+    int rxd = M5.getPin(m5::pin_name_t::port_c_rxd);
+    int txd = M5.getPin(m5::pin_name_t::port_c_txd);
+    Serial2.begin(115200, SERIAL_8N1, rxd, txd);
 
     /* Init module */
     module_llm.begin(&Serial2);

--- a/examples/TTS/TTS.ino
+++ b/examples/TTS/TTS.ino
@@ -22,9 +22,12 @@ void setup()
     // language = "zh_CN";
 
     /* Init module serial port */
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
-    // Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
-    // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
+    // int rxd = 16, txd = 17;  // Basic
+    // int rxd = 13, txd = 14;  // Core2
+    // int rxd = 18, txd = 17;  // CoreS3
+    int rxd = M5.getPin(m5::pin_name_t::port_c_rxd);
+    int txd = M5.getPin(m5::pin_name_t::port_c_txd);
+    Serial2.begin(115200, SERIAL_8N1, rxd, txd);
 
     /* Init module */
     module_llm.begin(&Serial2);

--- a/examples/TextAssistant/TextAssistant.ino
+++ b/examples/TextAssistant/TextAssistant.ino
@@ -17,9 +17,12 @@ void setup()
     M5.Display.setTextScroll(true);
 
     /* Init module serial port */
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
-    // Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
-    // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
+    // int rxd = 16, txd = 17;  // Basic
+    // int rxd = 13, txd = 14;  // Core2
+    // int rxd = 18, txd = 17;  // CoreS3
+    int rxd = M5.getPin(m5::pin_name_t::port_c_rxd);
+    int txd = M5.getPin(m5::pin_name_t::port_c_txd);
+    Serial2.begin(115200, SERIAL_8N1, rxd, txd);
 
     /* Init module */
     module_llm.begin(&Serial2);

--- a/examples/VoiceAssistant/VoiceAssistant.ino
+++ b/examples/VoiceAssistant/VoiceAssistant.ino
@@ -42,9 +42,12 @@ void setup()
     M5.Display.setTextScroll(true);
 
     /* Init module serial port */
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
-    // Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
-    // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
+    // int rxd = 16, txd = 17;  // Basic
+    // int rxd = 13, txd = 14;  // Core2
+    // int rxd = 18, txd = 17;  // CoreS3
+    int rxd = M5.getPin(m5::pin_name_t::port_c_rxd);
+    int txd = M5.getPin(m5::pin_name_t::port_c_txd);
+    Serial2.begin(115200, SERIAL_8N1, rxd, txd);
 
     /* Init module */
     module_llm.begin(&Serial2);

--- a/examples/YOLO/YOLO.ino
+++ b/examples/YOLO/YOLO.ino
@@ -28,9 +28,12 @@ void setup()
     M5.Display.setTextScroll(true);
 
     /* Init module serial port */
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
-    // Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
-    // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
+    // int rxd = 16, txd = 17;  // Basic
+    // int rxd = 13, txd = 14;  // Core2
+    // int rxd = 18, txd = 17;  // CoreS3
+    int rxd = M5.getPin(m5::pin_name_t::port_c_rxd);
+    int txd = M5.getPin(m5::pin_name_t::port_c_txd);
+    Serial2.begin(115200, SERIAL_8N1, rxd, txd);
 
     /* Init module */
     module_llm.begin(&Serial2);


### PR DESCRIPTION
M5Unified has a function getPin that gets the pin number of each port.
This pull request uses the M5.getPin function to save users the trouble of having to manually select pin settings when preparing Serial2.